### PR TITLE
Import backports during build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,8 +7,7 @@ build:
   script:
     - cd {{ SP_DIR if SP_DIR is defined else '' }}
     - mkdir backports && cd backports
-    - echo.>__init__.py    # [win]
-    - echo > __init__.py   # [unix]
+    - python -c "open('__init__.py', 'w').close()"
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ build:
     - mkdir backports && cd backports
     - python -c "open('__init__.py', 'w').close()"
     - cd {{ SRC_DIR if SRC_DIR is defined else '' }}
+    - python -c "import backports"
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,7 @@ build:
     - cd {{ SP_DIR if SP_DIR is defined else '' }}
     - mkdir backports && cd backports
     - python -c "open('__init__.py', 'w').close()"
+    - cd {{ SRC_DIR if SRC_DIR is defined else '' }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 1.0
 
 build:
-  number: 0
+  number: 1
   script:
     - cd {{ SP_DIR if SP_DIR is defined else '' }}
     - mkdir backports && cd backports


### PR DESCRIPTION
Just as a safety measure, make sure to import `backports` during the build. This as much a test as a build step. Though as `conda-build` compiles all Python files for us, it is not strictly necessary as a build step. Still it is good to have in case `conda-build` ever changes its behavior.